### PR TITLE
Fixes to make code compile with GCC 9.

### DIFF
--- a/testing/unit-tests/deferred_result_tests.cpp
+++ b/testing/unit-tests/deferred_result_tests.cpp
@@ -39,9 +39,6 @@ namespace
 	{
 		WTestException (int code): m_code (code) {}
 		const int m_code;
-
-   private:
-      WTestException& operator= (const WTestException&) { return *this; }
 	};	
 
    auto CountCallback (int& count)

--- a/testing/unit-tests/exception_capture_tests.cpp
+++ b/testing/unit-tests/exception_capture_tests.cpp
@@ -43,8 +43,6 @@ namespace
 
 		const std::string m_msg;
 
-   private:
-      WTestExc& operator= (const WTestExc&) { return *this; }
 	};
 }
 

--- a/testing/unit-tests/stm_test.cpp
+++ b/testing/unit-tests/stm_test.cpp
@@ -124,7 +124,16 @@ namespace
          m_val (t.m_val),
          m_index (varDtorIndex++)
       {}
-      
+
+      WVarDtorTester& operator= (const WVarDtorTester& t)
+      {
+         if (this != &t) {
+            m_val = t.m_val;
+            m_index = t.m_index;
+         }
+         return *this;
+      }
+
       ~WVarDtorTester ();
 
       int m_val;

--- a/wstm/deferred_result.h
+++ b/wstm/deferred_result.h
@@ -187,6 +187,19 @@ namespace WSTM
          m_core_p (value.m_core_p),
          m_watch_p (value.m_watch_p)
       {}
+
+      /**
+       * Copy Assignment Operator
+       */
+      WDeferredValueBase& operator= (const WDeferredValueBase& value)
+      {
+         if (this != &value) {
+            m_core_p = value.m_core_p;
+            m_watch_p = value.m_watch_p;
+         }
+
+         return *this;
+      }
          
       //@{
       /**


### PR DESCRIPTION
## Description

In GCC 9, lack of a user-defined copy assignment operator in presence of
a user-defined copy constructor, or vice versa, results in a warning
that is treated as an error by the build script.

## Testing

Both `Debug` and `Release` configurations build fine.
Unit tests succeeded.

Signed-off-by: Vladimir Krivopalov <vladimir.krivopalov@gmail.com>